### PR TITLE
Support MATE desktop environment detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /**/target/
 /**/*.swp
 /**/*.rs.bk
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /**/target/
 /**/*.swp
 /**/*.rs.bk
-.DS_Store

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -71,36 +71,6 @@ where
     Ok(OsString::from_vec(slice.to_vec()))
 }
 
-fn parse_desktop_env(env: &str) -> DesktopEnvironment {
-    if env.eq_ignore_ascii_case("AQUA") {
-        DesktopEnvironment::Aqua
-    } else if env.eq_ignore_ascii_case("GNOME") {
-        DesktopEnvironment::Gnome
-    } else if env.eq_ignore_ascii_case("LXDE") {
-        DesktopEnvironment::Lxde
-    } else if env.eq_ignore_ascii_case("OPENBOX") {
-        DesktopEnvironment::Openbox
-    } else if env.eq_ignore_ascii_case("MATE") {
-        DesktopEnvironment::Mate
-    } else if env.eq_ignore_ascii_case("I3") {
-        DesktopEnvironment::I3
-    } else if env.eq_ignore_ascii_case("UBUNTU") {
-        DesktopEnvironment::Ubuntu
-    } else if env.eq_ignore_ascii_case("PLASMA5") {
-        DesktopEnvironment::Plasma
-    } else if env.eq_ignore_ascii_case("XFCE") {
-        DesktopEnvironment::Xfce
-    } else if env.eq_ignore_ascii_case("NIRI") {
-        DesktopEnvironment::Niri
-    } else if env.eq_ignore_ascii_case("HYPRLAND") {
-        DesktopEnvironment::Hyprland
-    } else if env.eq_ignore_ascii_case("COSMIC") {
-        DesktopEnvironment::Cosmic
-    } else {
-        DesktopEnvironment::Unknown(env.to_string())
-    }
-}
-
 // This function must allocate, because a slice or `Cow<OsStr>` would still
 // reference `passwd` which is dropped when this function returns.
 #[inline(always)]
@@ -391,7 +361,33 @@ impl Target for Os {
             .unwrap_or_else(|e| e.to_string_lossy().into_owned())
             .into();
 
-        Some(parse_desktop_env(&env))
+        Some(if env.eq_ignore_ascii_case("AQUA") {
+            DesktopEnvironment::Aqua
+        } else if env.eq_ignore_ascii_case("GNOME") {
+            DesktopEnvironment::Gnome
+        } else if env.eq_ignore_ascii_case("LXDE") {
+            DesktopEnvironment::Lxde
+        } else if env.eq_ignore_ascii_case("OPENBOX") {
+            DesktopEnvironment::Openbox
+        } else if env.eq_ignore_ascii_case("MATE") {
+            DesktopEnvironment::Mate
+        } else if env.eq_ignore_ascii_case("I3") {
+            DesktopEnvironment::I3
+        } else if env.eq_ignore_ascii_case("UBUNTU") {
+            DesktopEnvironment::Ubuntu
+        } else if env.eq_ignore_ascii_case("PLASMA5") {
+            DesktopEnvironment::Plasma
+        } else if env.eq_ignore_ascii_case("XFCE") {
+            DesktopEnvironment::Xfce
+        } else if env.eq_ignore_ascii_case("NIRI") {
+            DesktopEnvironment::Niri
+        } else if env.eq_ignore_ascii_case("HYPRLAND") {
+            DesktopEnvironment::Hyprland
+        } else if env.eq_ignore_ascii_case("COSMIC") {
+            DesktopEnvironment::Cosmic
+        } else {
+            DesktopEnvironment::Unknown(env.to_string())
+        })
     }
 
     #[inline(always)]
@@ -463,18 +459,5 @@ impl Target for Os {
             "x86_64" | "amd64" | "i86pc" => CpuArchitecture::X64,
             _ => CpuArchitecture::Unknown(arch_str.into_owned()),
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_desktop_env;
-    use crate::DesktopEnvironment;
-
-    #[test]
-    fn parses_mate_desktop_environment() {
-        for name in ["MATE", "mate", "Mate"] {
-            assert_eq!(parse_desktop_env(name), DesktopEnvironment::Mate);
-        }
     }
 }

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -71,6 +71,36 @@ where
     Ok(OsString::from_vec(slice.to_vec()))
 }
 
+fn parse_desktop_env(env: &str) -> DesktopEnvironment {
+    if env.eq_ignore_ascii_case("AQUA") {
+        DesktopEnvironment::Aqua
+    } else if env.eq_ignore_ascii_case("GNOME") {
+        DesktopEnvironment::Gnome
+    } else if env.eq_ignore_ascii_case("LXDE") {
+        DesktopEnvironment::Lxde
+    } else if env.eq_ignore_ascii_case("OPENBOX") {
+        DesktopEnvironment::Openbox
+    } else if env.eq_ignore_ascii_case("MATE") {
+        DesktopEnvironment::Mate
+    } else if env.eq_ignore_ascii_case("I3") {
+        DesktopEnvironment::I3
+    } else if env.eq_ignore_ascii_case("UBUNTU") {
+        DesktopEnvironment::Ubuntu
+    } else if env.eq_ignore_ascii_case("PLASMA5") {
+        DesktopEnvironment::Plasma
+    } else if env.eq_ignore_ascii_case("XFCE") {
+        DesktopEnvironment::Xfce
+    } else if env.eq_ignore_ascii_case("NIRI") {
+        DesktopEnvironment::Niri
+    } else if env.eq_ignore_ascii_case("HYPRLAND") {
+        DesktopEnvironment::Hyprland
+    } else if env.eq_ignore_ascii_case("COSMIC") {
+        DesktopEnvironment::Cosmic
+    } else {
+        DesktopEnvironment::Unknown(env.to_string())
+    }
+}
+
 // This function must allocate, because a slice or `Cow<OsStr>` would still
 // reference `passwd` which is dropped when this function returns.
 #[inline(always)]
@@ -361,31 +391,7 @@ impl Target for Os {
             .unwrap_or_else(|e| e.to_string_lossy().into_owned())
             .into();
 
-        Some(if env.eq_ignore_ascii_case("AQUA") {
-            DesktopEnvironment::Aqua
-        } else if env.eq_ignore_ascii_case("GNOME") {
-            DesktopEnvironment::Gnome
-        } else if env.eq_ignore_ascii_case("LXDE") {
-            DesktopEnvironment::Lxde
-        } else if env.eq_ignore_ascii_case("OPENBOX") {
-            DesktopEnvironment::Openbox
-        } else if env.eq_ignore_ascii_case("I3") {
-            DesktopEnvironment::I3
-        } else if env.eq_ignore_ascii_case("UBUNTU") {
-            DesktopEnvironment::Ubuntu
-        } else if env.eq_ignore_ascii_case("PLASMA5") {
-            DesktopEnvironment::Plasma
-        } else if env.eq_ignore_ascii_case("XFCE") {
-            DesktopEnvironment::Xfce
-        } else if env.eq_ignore_ascii_case("NIRI") {
-            DesktopEnvironment::Niri
-        } else if env.eq_ignore_ascii_case("HYPRLAND") {
-            DesktopEnvironment::Hyprland
-        } else if env.eq_ignore_ascii_case("COSMIC") {
-            DesktopEnvironment::Cosmic
-        } else {
-            DesktopEnvironment::Unknown(env.to_string())
-        })
+        Some(parse_desktop_env(&env))
     }
 
     #[inline(always)]
@@ -457,5 +463,18 @@ impl Target for Os {
             "x86_64" | "amd64" | "i86pc" => CpuArchitecture::X64,
             _ => CpuArchitecture::Unknown(arch_str.into_owned()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_desktop_env;
+    use crate::DesktopEnvironment;
+
+    #[test]
+    fn parses_mate_desktop_environment() {
+        for name in ["MATE", "mate", "Mate"] {
+            assert_eq!(parse_desktop_env(name), DesktopEnvironment::Mate);
+        }
     }
 }

--- a/whoami/tests/desktop_env.rs
+++ b/whoami/tests/desktop_env.rs
@@ -1,0 +1,13 @@
+#![cfg(all(unix, not(target_vendor = "apple")))]
+
+use whoami::DesktopEnvironment;
+
+#[test]
+fn detects_mate_desktop_environment() {
+    for name in ["SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION"] {
+        std::env::remove_var(name);
+    }
+    std::env::set_var("XDG_SESSION_DESKTOP", "MATE");
+
+    assert_eq!(whoami::desktop_env(), Some(DesktopEnvironment::Mate));
+}

--- a/whoami/tests/desktop_env.rs
+++ b/whoami/tests/desktop_env.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, not(target_vendor = "apple")))]
+#![cfg(all(unix, not(target_vendor = "apple"), feature = "std"))]
 
 use whoami::DesktopEnvironment;
 


### PR DESCRIPTION
Fixes #173

Detect MATE from the Unix desktop-session environment variables that whoami already reads. The comparison is case-insensitive.

A non-Apple Unix integration test sets the desktop-session environment and exercises the public `whoami::desktop_env()` path.

## Testing / Verification

- `cargo test --all`
- `cargo test -p whoami --no-default-features --features std`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p whoami --all-targets --no-default-features --features std -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc -p whoami --no-deps`
- `git diff --check`

The new integration test is gated to non-Apple Unix because the Apple implementation intentionally reports Aqua; the Linux CI run provides the end-to-end MATE assertion.

AI assistance: OpenAI Codex was used for implementation and local verification.
